### PR TITLE
Internal field access

### DIFF
--- a/lib/field_serializer.rb
+++ b/lib/field_serializer.rb
@@ -12,18 +12,19 @@ module FieldSerializer
   module ClassMethods
 
     def fields
-      @fields ||= {}
+      @fields ||= []
     end
 
     def field(name, &block)
-      fields[name] = block
+      fields << name
+      define_method(name, &block)
     end
 
   end
 
   def to_h
-    self.class.fields.map { |name, block|
-      v = instance_eval(&block) rescue nil
+    self.class.fields.map { |name|
+      v = __send__(name)
       [name, v]
     }.to_h
   end

--- a/test/field_serializer_test.rb
+++ b/test/field_serializer_test.rb
@@ -46,4 +46,26 @@ describe FieldSerializer  do
       ConstructorTestThing.new(subject: 'abc').to_h.must_equal foo: 3
     end
   end
+
+  describe 'internal methods' do
+    class InternalFieldTest
+      include FieldSerializer
+
+      field :constituency do
+        'Bungudu'
+      end
+
+      field :state do
+        'Zamfara'
+      end
+
+      field :area do
+        [constituency, state].join(', ')
+      end
+    end
+
+    it 'allows other fields to be accessed as methods' do
+      InternalFieldTest.new.area.must_equal 'Bungudu, Zamfara'
+    end
+  end
 end


### PR DESCRIPTION
This makes the `field` method behave as if you were defining a method, allowing you to use field in other fields, for example:

``` ruby
class MemberPage
  include FieldSerializer

  field :constituency do
    box.xpath('.//th[text()="Constituency"]/following-sibling::td').text.tidy
  end

  field :state do
    box.xpath('.//th[text()="State"]/following-sibling::td').text.tidy
  end

  field :area do
    [constituency, state].join(', ')
  end
end
```

Fixes #3 
## Notes to merger

This is currently against the `fix-broken-test` branch, so once that's merged this pull request should be pointed to `master` before merging.
