### PR TITLE
Ensure subclasses inherit fields

### DIFF
--- a/lib/field_serializer.rb
+++ b/lib/field_serializer.rb
@@ -23,9 +23,30 @@ module FieldSerializer
   end
 
   def to_h
-    self.class.fields.map { |name|
+    all_fields.map { |name|
       v = __send__(name)
       [name, v]
     }.to_h
+  end
+
+  private
+
+  def all_fields
+    super_fields + self.class.fields
+  end
+
+  def super_fields
+    return [] unless superclass_implements_field_serializer?
+    self.class.superclass.fields
+  end
+
+  def superclass_implements_field_serializer?
+    superclass_responds_to?(:field, :fields)
+  end
+
+  def superclass_responds_to?(*methods)
+    methods.reduce('true') do | r, method |
+      r &&= self.class.superclass.respond_to? method
+    end
   end
 end

--- a/lib/field_serializer.rb
+++ b/lib/field_serializer.rb
@@ -10,6 +10,9 @@ module FieldSerializer
   end
 
   module ClassMethods
+    def inherited(subclass)
+      subclass.fields.concat(fields)
+    end
 
     def fields
       @fields ||= []
@@ -23,30 +26,9 @@ module FieldSerializer
   end
 
   def to_h
-    all_fields.map { |name|
+    self.class.fields.map { |name|
       v = __send__(name)
       [name, v]
     }.to_h
-  end
-
-  private
-
-  def all_fields
-    super_fields + self.class.fields
-  end
-
-  def super_fields
-    return [] unless superclass_implements_field_serializer?
-    self.class.superclass.fields
-  end
-
-  def superclass_implements_field_serializer?
-    superclass_responds_to?(:field, :fields)
-  end
-
-  def superclass_responds_to?(*methods)
-    methods.reduce('true') do | r, method |
-      r &&= self.class.superclass.respond_to? method
-    end
   end
 end

--- a/test/field_serializer_test.rb
+++ b/test/field_serializer_test.rb
@@ -94,12 +94,26 @@ describe FieldSerializer  do
       end
     end
 
+    class InheritanceSubclassTest3 < InheritanceSubclassTest2
+      field :constituency do
+        'Wibble'
+      end
+
+      field :district do
+        'Bar'
+      end
+    end
+
     it 'should return fields defined by parent class in #to_h' do
       InheritanceSubclassTest.new.to_h.must_equal(constituency: 'Bungudu', state: 'Zamfara')
     end
 
     it 'should use its own field in favour of one with a matching name set in parent' do
       InheritanceSubclassTest2.new.to_h.must_equal(constituency: 'Chafe', state: 'Zamfara')
+    end
+
+    it 'should allow subclasses to be subclassed' do
+      InheritanceSubclassTest3.new.to_h.must_equal(constituency: 'Wibble', state: 'Zamfara', district: 'Bar')
     end
   end
 end

--- a/test/field_serializer_test.rb
+++ b/test/field_serializer_test.rb
@@ -68,4 +68,24 @@ describe FieldSerializer  do
       InternalFieldTest.new.area.must_equal 'Bungudu, Zamfara'
     end
   end
+
+  describe 'inheritance' do
+    class InheritanceTest
+      include FieldSerializer
+
+      field :constituency do
+        'Bungudu'
+      end
+    end
+
+    class InheritanceSubclassTest < InheritanceTest
+      field :state do
+        'Zamfara'
+      end
+    end
+
+    it 'returns fields from the parent class in #to_h' do
+      InheritanceSubclassTest.new.to_h.must_equal(constituency: 'Bungudu', state: 'Zamfara')
+    end
+  end
 end

--- a/test/field_serializer_test.rb
+++ b/test/field_serializer_test.rb
@@ -84,8 +84,22 @@ describe FieldSerializer  do
       end
     end
 
+    class InheritanceSubclassTest2 < InheritanceTest
+      field :constituency do
+        'Chafe'
+      end
+
+      field :state do
+        'Zamfara'
+      end
+    end
+
     it 'returns fields from the parent class in #to_h' do
       InheritanceSubclassTest.new.to_h.must_equal(constituency: 'Bungudu', state: 'Zamfara')
+    end
+
+    it 'returns the field set in the subclass in #to_h' do
+      InheritanceSubclassTest2.new.to_h.must_equal(constituency: 'Chafe', state: 'Zamfara')
     end
   end
 end

--- a/test/field_serializer_test.rb
+++ b/test/field_serializer_test.rb
@@ -69,7 +69,7 @@ describe FieldSerializer  do
     end
   end
 
-  describe 'inheritance' do
+  describe 'a subclass inheriting from a class that uses FieldSerializer' do
     class InheritanceTest
       include FieldSerializer
 
@@ -94,11 +94,11 @@ describe FieldSerializer  do
       end
     end
 
-    it 'returns fields from the parent class in #to_h' do
+    it 'should return fields defined by parent class in #to_h' do
       InheritanceSubclassTest.new.to_h.must_equal(constituency: 'Bungudu', state: 'Zamfara')
     end
 
-    it 'returns the field set in the subclass in #to_h' do
+    it 'should use its own field in favour of one with a matching name set in parent' do
       InheritanceSubclassTest2.new.to_h.must_equal(constituency: 'Chafe', state: 'Zamfara')
     end
   end


### PR DESCRIPTION
This adds an `inherited` hook to ensure that subclasses inherit fields correctly.

Fixes #6 