### PR TITLE
Require Ruby >= 2.1 in gemspec

### DIFF
--- a/field_serializer.gemspec
+++ b/field_serializer.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = '>= 2.1'
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
We're using `Array#to_h` in `ClassMethods#to_h`, so we need a Ruby >= 2.1.

Fixes #2 
