### PR TITLE
Remove initialize method from FieldSerializer module

### DIFF
--- a/lib/field_serializer.rb
+++ b/lib/field_serializer.rb
@@ -5,10 +5,6 @@ module FieldSerializer
     klass.extend(ClassMethods)
   end
 
-  def initialize(options = {})
-    options.each { |o, v| define_singleton_method(o) { v } }
-  end
-
   module ClassMethods
 
     def fields

--- a/test/field_serializer_test.rb
+++ b/test/field_serializer_test.rb
@@ -33,20 +33,6 @@ describe FieldSerializer  do
     end
   end
 
-  describe 'class with constructor arguments' do
-    class ConstructorTestThing
-      include FieldSerializer
-
-      field :foo do
-        subject.length
-      end
-    end
-
-    it 'should return the length of the constructor argument' do
-      ConstructorTestThing.new(subject: 'abc').to_h.must_equal foo: 3
-    end
-  end
-
   describe 'internal methods' do
     class InternalFieldTest
       include FieldSerializer


### PR DESCRIPTION
This causes problems because this initialize method can clash with the
initialize method in other classes, causing unexpected errors depending
on the order that things are defined.

It seems like the best thing to do is remove this entirely. Then it's up
to other libraries (such as `scraped_page`) to provide a proper
initializer.

This will be useful for https://github.com/everypolitician/scraped_page/pull/6 where I'm using this module (specifically see https://github.com/everypolitician/scraped_page/pull/6/commits/1b5c183e78c6ba5de11fd9ccb03478204aebd549).

Fixes #9 
